### PR TITLE
Use /bin/sh and echo shell built-in.

### DIFF
--- a/md-timeouts.rules.strategy0
+++ b/md-timeouts.rules.strategy0
@@ -55,7 +55,7 @@ ACTION=="add|change", \
   ENV{MD_LEVEL}=="raid[1-9]*", \
   TEST=="/sys/block/$parent/device/timeout", \
   TEST=="/usr/sbin/smartctl", \
-  PROGRAM!="/usr/bin/sh -c '/usr/sbin/smartctl -l scterc /dev/$parent | grep -q seconds && exit 0 || exit 1'", \
-  RUN+="/usr/bin/sh -c '/usr/bin/echo 180 > /sys/block/$parent/device/timeout && /usr/bin/logger timeout for /dev/$parent set to 180 secs'"
+  PROGRAM!="/bin/sh -c '/usr/sbin/smartctl -l scterc /dev/$parent | grep -q seconds && exit 0 || exit 1'", \
+  RUN+="/bin/sh -c 'echo 180 > /sys/block/$parent/device/timeout && /usr/bin/logger timeout for /dev/$parent set to 180 secs'"
 
 LABEL="md_timeouts_end"


### PR DESCRIPTION
`/usr/bin/sh` and `/usr/bin/echo` don't exist on some systems that keep separate
`/bin` and `/usr/bin` directories.

`/bin/sh` has historically been the location of the Bourne shell. Even modern
systems that migrated to only having `/usr/bin` still symlink `/bin` to `/usr/bin` so
using `/bin/sh` should work on those as well.

Using shell built-in instead of `/usr/bin/echo` should be safe as well.